### PR TITLE
Update parse_settings.py

### DIFF
--- a/support/parse_settings.py
+++ b/support/parse_settings.py
@@ -19,6 +19,6 @@ for settings_file in settings_files:
             pass
 
 try:
-    print config[sys.argv[1]]
+    print (config[sys.argv[1]])
 except Exception:
     sys.exit(1)


### PR DESCRIPTION
******@******:~/nebula-setup$ sudo ./create_db.sh
  File "./support/parse_settings.py", line 22
    print config[sys.argv[1]]
          ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print(config[sys.argv[1]])?
  File "./support/parse_settings.py", line 22
    print config[sys.argv[1]]
          ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print(config[sys.argv[1]])?
  File "./support/parse_settings.py", line 22
    print config[sys.argv[1]]
          ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print(config[sys.argv[1]])?

DB connection params unspecified